### PR TITLE
Add minimal pre-commit configuration for prow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: detect-private-key

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,13 @@
+presubmits:
+  - name: pre-commit
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: aicoe-ci/prow/pre-commit
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.15.0
+          command:
+            - "pre-commit"
+            - "run"
+            - "--all-files"


### PR DESCRIPTION
`prow` [expects](https://github.com/operate-first/apps/blob/a5891fb1755e2d0782a898eb4213a4b767d610c1/prow/overlays/smaug/config.yaml#L110-L115) a pre-commit presubmit job to succeed on PRs.

This adds a minimal pre-commit configuration to meet this requirement.

**NOTE:** we do not want to add more pre-commit checks that cause changes that diverge from upstream, as this complicates tracking upstream a lot. The only check added here (check leaked keys) is expected to not ever cause such changes - and in the unlikely event this check ever triggers, it's hopefully for a good reason.